### PR TITLE
Pieter/net 1233 upgrade shadow cljs 2252

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "coverage": "jest --coverage",
     "flow": "flow",
     "build:cjs": "cross-env NODE_ENV=production babel --config-file ./babel.config.js ./src --out-dir ./lib --ignore \"**/*.test.js\"",
-    "prepare": "npm run build:cjs"
+    "prepare": "npm run lib"
   },
   "files": [
     "*.md",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test": "jest",
     "coverage": "jest --coverage",
     "flow": "flow",
-    "build:cjs": "cross-env NODE_ENV=production babel --config-file ./babel.config.js ./src --out-dir ./lib --ignore \"**/*.test.js\""
+    "build:cjs": "cross-env NODE_ENV=production babel --config-file ./babel.config.js ./src --out-dir ./lib --ignore \"**/*.test.js\"",
+    "prepare": "npm run build:cjs"
   },
   "files": [
     "*.md",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-easy-panzoom",
   "version": "0.8.0",
   "description": "Wrapper to enable pan and zoom for any React component",
-  "main": "./src/index.js",
+  "main": "./lib/index.js",
   "author": "mnogueron",
   "homepage": "https://mnogueron.github.io/react-easy-panzoom",
   "repository": {

--- a/src/PanZoom.js
+++ b/src/PanZoom.js
@@ -1,27 +1,23 @@
-// @flow-disabled
+// @flow
 
 import * as React from 'react'
 import warning from 'warning'
+import type { Coordinates, BoundCoordinates, TransformationParameters, TransformationMatrix } from './maths'
 import { TransformMatrix, getTransformedBoundingBox, getScaleMultiplier, boundCoordinates } from './maths'
 import { captureTextSelection, releaseTextSelection } from './events'
 
 const defaultNormalizeConfig = require('./config')
 
-/*::
-  import type { Coordinates, BoundCoordinates, TransformationParameters, TransformationMatrix } from './maths'
-*/
 
-/*::
- type OnStateChangeData = {
-   x: number,
-   y: number,
-   scale: number,
-   angle: number
- }
-*/
+type OnStateChangeData = {
+    x: number,
+    y: number,
+    scale: number,
+    angle: number
+}
 
-/*::
- type Props = {
+
+type Props = {
    zoomSpeed: number,
    doubleZoomSpeed: number,
    disabled?: boolean,
@@ -47,16 +43,13 @@ const defaultNormalizeConfig = require('./config')
    onPanEnd?: (any) => void,
    onStateChange?: (data: OnStateChangeData) => void,
  } & React.ElementProps<'div'>
-*/
 
-/*::
-  type State = {
+type State = {
    x: number,
    y: number,
    scale: number,
    angle: number
-  }
-*/
+}
 
 const getTransformMatrixString = (transformationMatrix /*: TransformationMatrix */) => {
   const { a, b, c, d, x, y } = transformationMatrix
@@ -120,7 +113,7 @@ function isSimilar2DVector(prevDirection, nextDirection) {
   return isSimilar1DComponent(x1, x2) && isSimilar1DComponent(y1, y2)
 }
 
-export class PanZoom extends React.Component /* React.Component<Props,State> */ {
+export class PanZoom extends React.Component<Props,State> {
   static defaultProps = {
     zoomSpeed: 1,
     doubleZoomSpeed: 1.75,
@@ -139,8 +132,8 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     preventPan: () => false,
   }
 
-  container = React.createRef()
-  dragContainer = React.createRef()
+  container = React.createRef<HTMLDivElement>()
+  dragContainer = React.createRef<HTMLDivElement>()
 
   mousePos = {
     x: 0,
@@ -163,7 +156,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
   transformMatrixString = `matrix(1, 0, 0, 1, 0, 0)`
   intermediateTransformMatrixString = `matrix(1, 0, 0, 1, 0, 0)`
 
-  state /*: State */ = {
+  state : State = {
     x: 0,
     y: 0,
     scale: 1,
@@ -187,7 +180,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  componentDidMount()/*: void */ {
+  componentDidMount(): void {
     const { autoCenter, autoCenterZoomLevel, minZoom, maxZoom, normalizeConfig } = this.props
 
     this.normalizeConfig = Object.assign({}, defaultNormalizeConfig, normalizeConfig)
@@ -204,7 +197,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  componentDidUpdate(prevProps /*: Props */, prevState /*: State */) /*: void */ {
+  componentDidUpdate(prevProps : Props, prevState : State) : void {
     if (prevProps.autoCenter !== this.props.autoCenter
       && this.props.autoCenter) {
       this.autoCenter(this.props.autoCenterZoomLevel)
@@ -225,7 +218,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  componentWillUnmount() /*: void */ {
+  componentWillUnmount() : void {
     this.cleanMouseListeners()
     this.cleanTouchListeners()
     releaseTextSelection()
@@ -234,7 +227,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onDoubleClick = (e /*: MouseEvent */) => {
+  onDoubleClick = (e : MouseEvent) => {
     const { onDoubleClick, disableDoubleClickZoom, doubleZoomSpeed } = this.props
 
     if (typeof onDoubleClick === 'function') {
@@ -249,7 +242,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.zoomTo(offset.x, offset.y, doubleZoomSpeed)
   }
 
-  onMouseDown = (e /*: MouseEvent */) => {
+  onMouseDown = (e : MouseEvent) => {
     const { preventPan, onMouseDown, noStateUpdate } = this.props
 
     if (typeof onMouseDown === 'function') {
@@ -309,7 +302,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     captureTextSelection()
   }
 
-  onMouseMove = (e /*: MouseEvent */) => {
+  onMouseMove = (e : MouseEvent) => {
     if (this.panning) {
       const { noStateUpdate } = this.props
 
@@ -331,7 +324,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onMouseUp = (e /*: MouseEvent */) => {
+  onMouseUp = (e : MouseEvent) => {
     const { noStateUpdate } = this.props
 
     // if using noStateUpdate we still need to set the new values in the state
@@ -359,7 +352,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.wheelZooming = false
   }
 
-  onWheel = (e /*: WheelEvent */) => {
+  onWheel = (e : WheelEvent) => {
     const {
       disableScrollZoom,
       disabled,
@@ -503,7 +496,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.prevNormalizedEvent = normalizedEvent
   }
 
-  onKeyDown = (e /*: SyntheticKeyboardEvent<HTMLDivElement> */) => {
+  onKeyDown = (e : SyntheticKeyboardEvent<HTMLDivElement>) => {
     const { keyMapping, disableKeyInteraction, onKeyDown } = this.props
 
     if (typeof onKeyDown === 'function') {
@@ -548,7 +541,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onKeyUp = (e /*: SyntheticKeyboardEvent<HTMLDivElement> */) => {
+  onKeyUp = (e : SyntheticKeyboardEvent<HTMLDivElement>) => {
     const { disableKeyInteraction, onKeyDown } = this.props
 
     if (typeof onKeyDown === 'function') {
@@ -564,7 +557,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onTouchStart = (e /*: SyntheticTouchEvent<HTMLDivElement> */) => {
+  onTouchStart = (e : SyntheticTouchEvent<HTMLDivElement>) => {
     const { preventPan, onTouchStart, disabled } = this.props
     if (typeof onTouchStart === 'function') {
       onTouchStart(e)
@@ -615,7 +608,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onToucheMove = (e /*: TouchEvent */) => {
+  onToucheMove = (e : TouchEvent) => {
     const { realPinch, noStateUpdate, zoomSpeed } = this.props
     if (e.touches.length === 1) {
       e.stopPropagation()
@@ -665,7 +658,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  onTouchEnd = (e /*: TouchEvent */) => {
+  onTouchEnd = (e : TouchEvent ) => {
     if (e.touches.length > 0) {
       const offset = this.getOffset(e.touches[0])
       this.mousePos = {
@@ -734,7 +727,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  triggerOnPanStart = (e /*: MouseEvent | TouchEvent */) => {
+  triggerOnPanStart = (e : MouseEvent | TouchEvent ) => {
     const { onPanStart } = this.props
     if (!this.panStartTriggered && onPanStart && typeof onPanStart === 'function') {
       onPanStart(e)
@@ -742,14 +735,14 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.panStartTriggered = true
   }
 
-  triggerOnPan = (e /*: MouseEvent | TouchEvent */) => {
+  triggerOnPan = (e : MouseEvent | TouchEvent ) => {
     const { onPan } = this.props
     if (typeof onPan === 'function') {
       onPan(e)
     }
   }
 
-  triggerOnPanEnd = (e /*: MouseEvent | TouchEvent */) => {
+  triggerOnPanEnd = (e : MouseEvent | TouchEvent) => {
     const { onPanEnd } = this.props
     this.panStartTriggered = false
     if (typeof onPanEnd === 'function') {
@@ -757,14 +750,14 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  getPinchZoomLength = (finger1 /*: Touch */, finger2 /*: Touch */) /*: number */ => {
+  getPinchZoomLength = (finger1 : Touch , finger2 : Touch) : number => {
     return Math.sqrt(
       (finger1.clientX - finger2.clientX) * (finger1.clientX - finger2.clientX) +
       (finger1.clientY - finger2.clientY) * (finger1.clientY - finger2.clientY)
     )
   }
 
-  getContainer = () /*: HTMLDivElement */ => {
+  getContainer = () : HTMLDivElement => {
     const { current: container } = this.container
     if (!container) {
       throw new Error("Could not find container DOM element.")
@@ -772,7 +765,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     return container
   }
 
-  getDragContainer = () /*: HTMLDivElement */ => {
+  getDragContainer = () : HTMLDivElement => {
     const { current: dragContainer } = this.dragContainer
     if (!dragContainer) {
       throw new Error("Could not find dragContainer DOM element.")
@@ -780,7 +773,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     return dragContainer
   }
 
-  autoCenter = (zoomLevel /*: number */ = 1, animate /*: boolean */ = true) => {
+  autoCenter = (zoomLevel : number = 1, animate : boolean = true) => {
     const container = this.getContainer()
     const dragContainer = this.getDragContainer()
     const { minZoom, maxZoom } = this.props
@@ -818,7 +811,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.setState({ x, y, scale, angle: 0 }, afterStateUpdate)
   }
 
-  moveByRatio = (x /*: number */, y /*: number */, moveSpeedRatio /*: number */ = 0.05) => {
+  moveByRatio = (x : number, y : number, moveSpeedRatio : number = 0.05) => {
     const container = this.getContainer()
     const containerRect = container.getBoundingClientRect()
     const offset = Math.min(containerRect.width, containerRect.height)
@@ -828,7 +821,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.moveBy(dx, dy, false)
   }
 
-  moveBy = (dx /*: number */, dy /*: number */, noStateUpdate /*?: boolean */ = true) => {
+  moveBy = (dx : number, dy : number, noStateUpdate ?: boolean = true) => {
     const { x, y, scale, angle } = this.state
 
     // Allow better performance by not updating the state on every change
@@ -867,9 +860,9 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     }
   }
 
-  rotate = (value /*: number | (prevAngle: number) => number */) => {
+  rotate = (value : number | (prevAngle: number) => number) => {
     const { angle } = this.state
-    let newAngle /*: number */
+    let newAngle : number
     if (typeof value === 'function') {
       newAngle = value(angle)
     } else {
@@ -878,11 +871,11 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.setState({ angle: newAngle })
   }
 
-  zoomAbs = (x /*: number */, y /*: number */, zoomLevel /*: number */) => {
+  zoomAbs = (x : number, y : number, zoomLevel : number) => {
     this.zoomTo(x, y, zoomLevel / this.state.scale)
   }
 
-  zoomTo = (x /*: number */, y /*: number */, ratio /*: number */) => {
+  zoomTo = (x : number, y : number, ratio : number) => {
     const { minZoom, maxZoom } = this.props
     const { x: transformX, y: transformY, scale, angle } = this.state
 
@@ -910,18 +903,18 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.setState({ x: boundX, y: boundY, scale: newScale })
   }
 
-  centeredZoom = (delta /*: number */, zoomSpeed /*?: number */) => {
+  centeredZoom = (delta: number , zoomSpeed?: number ) => {
     const container = this.getContainer()
     const scaleMultiplier = getScaleMultiplier(delta, zoomSpeed || this.props.zoomSpeed)
     const containerRect = container.getBoundingClientRect()
     this.zoomTo(containerRect.width / 2, containerRect.height / 2, scaleMultiplier)
   }
 
-  zoomIn = (zoomSpeed /*?: number */) => {
+  zoomIn = (zoomSpeed?: number) => {
     this.centeredZoom(-1, zoomSpeed)
   }
 
-  zoomOut = (zoomSpeed /*?: number */) => {
+  zoomOut = (zoomSpeed?: number) => {
     this.centeredZoom(1, zoomSpeed)
   }
 
@@ -929,18 +922,18 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.setState({ x: 0, y: 0, scale: 1, angle: 0 })
   }
 
-  getContainerBoundingRect = () /*: ClientRect */ => {
+  getContainerBoundingRect = () : ClientRect => {
     return this.getContainer().getBoundingClientRect()
   }
 
-  getOffset = (e /*: MouseEvent | Touch */) /*: Coordinates */ => {
+  getOffset = (e : MouseEvent | Touch) : Coordinates => {
     const containerRect = this.getContainerBoundingRect()
     const offsetX = e.clientX - containerRect.left
     const offsetY = e.clientY - containerRect.top
     return { x: offsetX, y: offsetY }
   }
 
-  getTransformMatrix = (x /*: number */, y /*: number */, scale /*: number */, angle /*: number */) /*: TransformationMatrix */ => {
+  getTransformMatrix = (x : number, y : number, scale : number, angle : number) : TransformationMatrix => {
     if (!this.dragContainer.current) {
       return { a: scale, b: 0, c: 0, d: scale, x, y }
     }
@@ -964,7 +957,7 @@ export class PanZoom extends React.Component /* React.Component<Props,State> */ 
     this.intermediateFrameAnimation = 0
   }
 
-  getBoundCoordinates = (coordinates /*: Coordinates */, transformationParameters /*: TransformationParameters */) /*: BoundCoordinates */ => {
+  getBoundCoordinates = (coordinates : Coordinates, transformationParameters : TransformationParameters) : BoundCoordinates => {
     const { x, y } = coordinates
     const { enableBoundingBox, boundaryRatioVertical, boundaryRatioHorizontal } = this.props
     const { offsetX = 0, offsetY = 0 } = transformationParameters

--- a/src/maths.js
+++ b/src/maths.js
@@ -1,4 +1,3 @@
-/*::
 export type TransformationMatrix = {
   a: number,
   b: number,
@@ -7,43 +6,27 @@ export type TransformationMatrix = {
   x: number,
   y: number,
 }
-*/
-
-/*::
 export type BoundingBox = {
   top: number,
   left: number,
   width: number,
   height: number,
 }
-*/
-
-/*::
 export type BoundaryRatio = {
   vertical: number,
   horizontal: number,
 }
-*/
-
-/*::
 export type Coordinates = {
   x: number,
   y: number,
 }
-*/
-
-/*::
 export type BoundCoordinates = { boundX: number, boundY: number, offsetX: number, offsetY: number }
-*/
-
-/*::
 export type TransformationParameters = {
   angle: number,
   scale: number,
   offsetX: number,
   offsetY: number,
 }
-*/
 
 export const ZOOM_SPEED_MULTIPLIER = 0.065
 
@@ -52,7 +35,7 @@ export const ZOOM_SPEED_MULTIPLIER = 0.065
 // ( a , c, x )
 // ( b , d, y )
 // ( 0 , 0, 1 )
-export const TransformMatrix = (transformationParameters /*: TransformationParameters */, centerCoordinates /*: Coordinates */, ) /*: TransformationMatrix */ => {
+export const TransformMatrix = (transformationParameters: TransformationParameters, centerCoordinates: Coordinates, ) : TransformationMatrix => {
   const { angle, scale, offsetX, offsetY } = transformationParameters
   const { x: centerX, y: centerY } = centerCoordinates
   const theta = angle * Math.PI / 180
@@ -65,7 +48,7 @@ export const TransformMatrix = (transformationParameters /*: TransformationParam
   return { a, b, c, d, x : transformX + offsetX, y: transformY + offsetY }
 }
 
-const applyTransformMatrix = (transformationParameters /*: TransformationParameters */, centerCoordinates /*: Coordinates */) => (x, y) /*: [number, number] */ => {
+const applyTransformMatrix = (transformationParameters: TransformationParameters, centerCoordinates: Coordinates) => (x, y): [number, number] => {
   const { a, b, c, d, x: transformX, y: transformY } = TransformMatrix(transformationParameters, centerCoordinates)
   return [
     x * a + y * c + transformX,
@@ -73,7 +56,7 @@ const applyTransformMatrix = (transformationParameters /*: TransformationParamet
   ]
 }
 
-export const getTransformedBoundingBox = (transformationParameters /*: TransformationParameters */, boundingBox /*: BoundingBox */) /*: BoundingBox */ => {
+export const getTransformedBoundingBox = (transformationParameters: TransformationParameters, boundingBox: BoundingBox) : BoundingBox => {
   const { top, left, width, height } = boundingBox
   const center = {
     x: width / 2,
@@ -95,7 +78,7 @@ export const getTransformedBoundingBox = (transformationParameters /*: Transform
   }
 }
 
-export const getScaleMultiplier = (delta /*: number */, zoomSpeed /*: number */ = 1) /*: number */ => {
+export const getScaleMultiplier = (delta: number, zoomSpeed: number = 1) : number => {
   let speed = ZOOM_SPEED_MULTIPLIER * zoomSpeed
   let scaleMultiplier = 1
   if (delta > 0) { // zoom out
@@ -108,11 +91,11 @@ export const getScaleMultiplier = (delta /*: number */, zoomSpeed /*: number */ 
 }
 
 export const boundCoordinates = (
-  x /*: number */, y /*: number */,
-  boundaryRatio /*: BoundaryRatio */,
-  boundingBox /*: BoundingBox */,
-  containerHeight /*: number */, containerWidth /*: number */,
-  offsetX /*?: number */ = 0, offsetY /*?: number */ = 0) /*: BoundCoordinates */ => {
+  x: number, y: number,
+  boundaryRatio: BoundaryRatio,
+  boundingBox: BoundingBox,
+  containerHeight: number, containerWidth: number,
+  offsetX?: number = 0, offsetY?: number = 0) : BoundCoordinates => {
 
   const { top, left, width, height } = boundingBox
   // check that computed are inside boundaries otherwise set to the bounding box limits


### PR DESCRIPTION
# background

- shadow-cljs changed the way javascript dependencies are /something/
- shadow-cljs no longer use babel for /something/, but instead use the clojurescript compile implementation, which has different capabilities.
- This exposed some incompatibilities with the javascript in this library. 
- The fix is to do the actual packaging step as defined in this package's `package.json`.
- More info here: https://clojureverse.org/t/shadow-cljs-2-25-2-looking-for-testers/10206

# changes

- re-enable flow-js processing for this library
- change the exported directory to be `./lib` (again) instead of `./src`
- Undo the removal of type-annotations
- Add `prepare` script in `package.json`, that calls `lib` step, which performs the packaging required 